### PR TITLE
feat: allow deep links

### DIFF
--- a/apps/kilahm/src/404.html
+++ b/apps/kilahm/src/404.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <script>
+      history.replaceState(undefined, '', `/#${window.location.pathname}`);
+    </script>
+  </body>
+</html>

--- a/apps/kilahm/src/app/app.module.ts
+++ b/apps/kilahm/src/app/app.module.ts
@@ -1,17 +1,27 @@
-import { NgModule } from '@angular/core';
+import { Location } from '@angular/common';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
+import { environment } from '../environments/environment';
 import { AppComponent } from './app.component';
+import { followDeepLink } from './initialization';
 import { ResumeComponent } from './resume/resume.component';
 import { routes } from './routes';
-
 @NgModule({
   declarations: [AppComponent, ResumeComponent],
   imports: [
     BrowserModule,
-    RouterModule.forRoot(routes, { initialNavigation: 'enabled' }),
+    RouterModule.forRoot(routes, { initialNavigation: 'disabled', enableTracing:  !environment.production}),
   ],
-  providers: [],
+  providers: [
+    Location,
+    {
+      provide: APP_INITIALIZER,
+      useFactory: followDeepLink,
+      multi: true,
+      deps: [Location, Router],
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/apps/kilahm/src/app/initialization.ts
+++ b/apps/kilahm/src/app/initialization.ts
@@ -1,0 +1,17 @@
+import { Location } from '@angular/common';
+import { Router } from '@angular/router';
+
+export function followDeepLink(
+  location: Location,
+  router: Router,
+): () => Promise<void> {
+  return async () => {
+    const pathWithHash = location.path(true);
+    const pathInHash = pathWithHash.split('#')[1];
+    if (pathInHash === undefined) {
+      await router.navigate(['/']);
+      return;
+    }
+    await router.navigate([pathInHash]);
+  };
+}

--- a/apps/kilahm/src/app/routes.ts
+++ b/apps/kilahm/src/app/routes.ts
@@ -5,9 +5,5 @@ export const routes: Route[] = [
   {
     component: ResumeComponent,
     path: 'resume',
-  },
-  {
-    path: '**',
-    redirectTo: '/resume',
-  },
+  }
 ];

--- a/workspace.json
+++ b/workspace.json
@@ -21,7 +21,11 @@
             "polyfills": "apps/kilahm/src/polyfills.ts",
             "tsConfig": "apps/kilahm/tsconfig.app.json",
             "aot": true,
-            "assets": ["apps/kilahm/src/favicon.ico", "apps/kilahm/src/assets"],
+            "assets": [
+              "apps/kilahm/src/favicon.ico",
+              "apps/kilahm/src/assets",
+              "apps/kilahm/src/404.html"
+            ],
             "styles": ["apps/kilahm/src/styles.scss"],
             "scripts": []
           },


### PR DESCRIPTION

Provide a custom 404 page that uses the history api to redirect the browser to the index page with a
url hash to the path requested. Angular bootstrap then picks up on the has in the url to perform the
initial Angular router navigation.

fix #14