### PR TITLE
fix: reenable initial navigation

### DIFF
--- a/apps/kilahm/src/app/app.module.ts
+++ b/apps/kilahm/src/app/app.module.ts
@@ -10,7 +10,7 @@ import { routes } from './routes';
   imports: [
     BrowserModule,
     RouterModule.forRoot(routes, {
-      initialNavigation: 'disabled',
+      initialNavigation: 'enabled',
       enableTracing: !environment.production,
     }),
   ],


### PR DESCRIPTION

Need to have the router create an initial navigation event after removing the custom bootstrap logig